### PR TITLE
Anpassung der API Dokumentation

### DIFF
--- a/edudip-next-api-documentation-en.md
+++ b/edudip-next-api-documentation-en.md
@@ -16,7 +16,7 @@ In this document we will only specify the path of the endpoint. Each endpoint mu
 
 If an endpoint requires a list of parameters, these parameters must be encoded as multipart/form-data (https://www.w3.org/TR/html5/sec-forms.html#multipart-form-data) or application/x-www-form-urlencoded (https://www.w3.org/TR/html5/sec-forms.html#urlencoded-form-data).
 
-Each API request should also contain the HTTP header ```Accept``` with the value ```application/json```.
+Each API request must also contain the HTTP header ```Accept``` with the value ```application/json```.
 
 Example of an implementation of a POST request using PHP and cURL:
 

--- a/edudip-next-api-dokumentation.md
+++ b/edudip-next-api-dokumentation.md
@@ -16,7 +16,7 @@ In diesem Dokument geben wir nur den Pfad des Endpunktes an. Jedem Endpunkt ist 
 
 Sollte ein Endpunkt eine Liste von Parametern benötigen, so sind diese Parameter als ```multipart/form-data``` (https://www.w3.org/TR/html5/sec-forms.html#multipart-form-data) oder ```application/x-www-form-urlencoded``` (https://www.w3.org/TR/html5/sec-forms.html#urlencoded-form-data) in der HTTP Anfrage zu kodieren.
 
-Jede API Anfrage sollte zudem den HTTP Header ```Accept``` mit dem Wert ```application/json``` beinhalten.
+Jede API Anfrage muss zudem den HTTP Header ```Accept``` mit dem Wert ```application/json``` beinhalten.
 
 Beispiel für eine Implementierung einer POST Anfrage mittels PHP und cURL:
 


### PR DESCRIPTION
Es muss der Header Accept: application/json angegeben werden, sonst funktioniert die API nicht wie beschrieben.

Beispiel:
$ curl https://api.edudip-next.com/api/webinars/1539042 -H "Accept: application/json" -H "Authorization: Bearer xx" --head
HTTP/2 401

$ curl https://api.edudip-next.com/api/webinars/1539042 -H "Authorization: Bearer xx" --head
HTTP/2 302